### PR TITLE
Make ROS test pass on fresh Ubuntu 12.04

### DIFF
--- a/robustus/detail/install_ros.py
+++ b/robustus/detail/install_ros.py
@@ -89,8 +89,10 @@ def install(robustus, requirement_specifier, rob_file, ignore_index):
 
         # create catkin workspace
         rosdir = os.path.join(robustus.env, 'ros')
+        py_activate_file = os.path.join(robustus.env, 'bin', 'activate')
         catkin_make_isolated = os.path.join(ros_cache, 'src/catkin/bin/catkin_make_isolated')
-        retcode = run_shell(catkin_make_isolated + ' --install-space %s --install' % rosdir,
+        retcode = run_shell('. ' + py_activate_file + ' && ' +
+                            catkin_make_isolated + ' --install-space %s --install' % rosdir,
                             verbose=robustus.settings['verbosity'] >= 1)
         if retcode != 0:
             raise RequirementException('Failed to create catkin workspace for ROS')

--- a/robustus/tests/test_ros.py
+++ b/robustus/tests/test_ros.py
@@ -21,7 +21,7 @@ def test_ros_installation(tmpdir):
                           imports,
                           [],
                           dependencies,
-                          postinstall_script='source test_env/bin/activate && source test_env/ros/setup.sh')
+                          postinstall_script='. test_env/bin/activate && . test_env/ros/setup.sh')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I haven't turned it on on the test server because I think it will run out of time. But now passes on my fresh Ubuntu 12.04

Previously, there was an issue that it relied on some system versions of some packages, would may explain why it was succeeding on some machines but not others.
