### PR TITLE
Attempted fix for softlink to system file

### DIFF
--- a/robustus/detail/install_pygtk.py
+++ b/robustus/detail/install_pygtk.py
@@ -20,8 +20,10 @@ def install(robustus, requirement_specifier, rob_file, ignore_index):
             if not os.path.exists(src):
                 raise RequirementException('Required packages for system-wide PyGtk missing, %s not found' % f)
             ln(src, os.path.join(site_packages_dir, f), force=True)
-        write_file(os.path.join(site_packages_dir, 'pygtk.pth'),
-                   'w',
-                   os.path.join(site_packages_dir, 'gtk-2.0'))
+        pygtk_pth = os.path.join(site_packages_dir, 'pygtk.pth')
+        if not os.path.exists(pygtk_pth):
+            write_file(os.path.join(pygtk_pth),
+                       'w',
+                       os.path.join(site_packages_dir, 'gtk-2.0'))
     else:
         raise RequirementException('System-wide PyGtk is missing')   


### PR DESCRIPTION
@olegsinyavskiy I have not had a chance to test this on an actual robot.  I have verified that it does circumvent the permissions problem during the build, however.

Attempted fix for softlink to system file.  This softlink seems to already exist
and since it points to a system file owned by root, it cannot be written to
without root privileges.
