### PR TITLE
Robustus setup py

### DIFF
--- a/robustus/robustus.py
+++ b/robustus/robustus.py
@@ -197,7 +197,6 @@ class Robustus(object):
 
         logging.info('Robustus initialized environment with cache located at %s' % settings['cache'])
 
-
     def install_satisfactory_requirement_from_remote(self, requirement_specifier):
         """
         If wheel for satisfactory requirement found on remote, install it.


### PR DESCRIPTION
@olegsinyavskiy 

Install Robustus in the Python virtual environment if its "setup.py" is available.  If Robustus has already been installed in the virtual environment, running "setup.py" should be harmless.  This is required to pass the "test_robustus" test.
