### PR TITLE
Pip install external options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - sudo apt-get install -y --force-yes libswscale-dev libavformat-dev libavcodec-dev libogre-dev
   - sudo apt-get install -y --force-yes libgts-dev libltdl3-dev playerc++ libxml2-dev libfreeimage-dev freeglut3-dev
   - sudo apt-get install -y --force-yes python-gst0.10 python-cairo python-gobject-2
+  - sudo apt-get install -y --force-yes portaudio19-dev
   - source use_repo.sh
 script:
   - "./test"

--- a/README.md
+++ b/README.md
@@ -70,8 +70,21 @@ To ignore remote cache use --no-remote-cache flag:
     robustus install tornado==3.2.1 --no-remote-cache
 
 
-### Trouble shooting remote cache  
-Sometimes package version are not available in the remote wheelhouse, or fail to install correctly in ~/.robustus_rc. If you are having issues installing pip / python packages, try the following:  
+### Trouble shooting
+
+Pip 1.5 requires --allow-external, --allow-unverified to be specified for some packages.
+If you see error like this:
+
+    Downloading/unpacking PyAudio
+      Could not find any downloads that satisfy the requirement PyAudio
+      Some externally hosted files were ignored (use --allow-external PyAudio to allow).
+
+You should pass these options to robustus, so it'll bypass it to pip:
+
+    robustus install PyAudio --allow-all-external --allow-unverified PyAudio
+
+Sometimes package version are not available in the remote wheelhouse, or fail to install correctly in ~/.robustus_rc.
+If you are having issues installing pip / python packages, try the following:
 * Open a new shell, outside of the virtual environment  
 * $ rm ~/.robustus_rc/{package}.rob (Look around the directory, name will not match exactly)
 * $ pip install package==version (e.g. pep8==1.4.6)  

--- a/robustus/detail/test.py
+++ b/robustus/detail/test.py
@@ -24,7 +24,8 @@ def perform_standard_test(package,
                           postinstall_script=None,
                           test_env='test_env',
                           test_cache='test_wheelhouse',
-                          options=[]):
+                          options=[],
+                          install_options=[]):
     """
     create env, install package, check package is available,
     remove env, install package without index, check package is available
@@ -38,7 +39,7 @@ def perform_standard_test(package,
 
     robustus.execute(options + ['--debug', '--cache', test_cache, 'env', test_env])
     install_dependencies(test_env, dependencies, options)
-    robustus.execute(options + ['--debug', '--env', test_env, 'install', package])
+    robustus.execute(options + ['--debug', '--env', test_env, 'install', package] + install_options)
         
     check_module(test_env, python_imports, package_files, postinstall_script)
     shutil.rmtree(test_env)
@@ -46,7 +47,7 @@ def perform_standard_test(package,
     # install again, but using only cache
     robustus.execute(options + ['--debug', '--cache', test_cache, 'env', test_env])
     install_dependencies(test_env, dependencies, options)
-    robustus.execute(options + ['--debug', '--env', test_env, 'install', package, '--no-index'])
+    robustus.execute(options + ['--debug', '--env', test_env, 'install', package, '--no-index'] + install_options)
     check_module(test_env, python_imports, package_files, postinstall_script)
     shutil.rmtree(test_env)
     shutil.rmtree(test_cache)

--- a/robustus/robustus.py
+++ b/robustus/robustus.py
@@ -264,11 +264,11 @@ class Robustus(object):
                 logging.info('Wheel not found, downloading package')
                 cmd = [self.pip_executable, 'install', '--download', self.cache, requirement_specifier.freeze()]
                 if len(self.settings['allow_external']) > 0:
-                    cmd += ['--allow-external '] + self.settings['allow_external']
+                    cmd += ['--allow-external'] + self.settings['allow_external']
                 if self.settings['allow_all_external']:
                     cmd.append('--allow-all-external')
                 if len(self.settings['allow_unverified']) > 0:
-                    cmd += ['--allow-unverified '] + self.settings['allow_unverified']
+                    cmd += ['--allow-unverified'] + self.settings['allow_unverified']
                 return_code = run_shell(cmd, verbose=self.settings['verbosity'] >= 2)
                 if return_code != 0:
                     raise RequirementException('pip failed to download requirement %s' % requirement_specifier.freeze())

--- a/robustus/robustus.py
+++ b/robustus/robustus.py
@@ -262,13 +262,14 @@ class Robustus(object):
                 installed = self.install_satisfactory_requirement_from_remote(requirement_specifier)
             if not installed:
                 logging.info('Wheel not found, downloading package')
-                cmd = [self.pip_executable, 'install', '--download', self.cache, requirement_specifier.freeze()]
+                cmd = [self.pip_executable, 'install']
                 if len(self.settings['allow_external']) > 0:
                     cmd += ['--allow-external'] + self.settings['allow_external']
                 if self.settings['allow_all_external']:
                     cmd.append('--allow-all-external')
                 if len(self.settings['allow_unverified']) > 0:
                     cmd += ['--allow-unverified'] + self.settings['allow_unverified']
+                cmd += ['--download', self.cache, requirement_specifier.freeze()]
                 return_code = run_shell(cmd, verbose=self.settings['verbosity'] >= 2)
                 if return_code != 0:
                     raise RequirementException('pip failed to download requirement %s' % requirement_specifier.freeze())

--- a/robustus/robustus.py
+++ b/robustus/robustus.py
@@ -263,10 +263,12 @@ class Robustus(object):
             if not installed:
                 logging.info('Wheel not found, downloading package')
                 cmd = [self.pip_executable, 'install', '--download', self.cache, requirement_specifier.freeze()]
+                if len(self.settings['allow_external']) > 0:
+                    cmd.append('--allow-external ' + ' '.join(self.settings['allow_external']))
                 if self.settings['allow_all_external']:
                     cmd.append('--allow-all-external')
-                if self.settings['allow_all_unverified']:
-                    cmd.append('--allow-all-unverified')
+                if len(self.settings['allow_unverified']) > 0:
+                    cmd.append('--allow-unverified ' + ' '.join(self.settings['allow_unverified']))
                 return_code = run_shell(cmd, verbose=self.settings['verbosity'] >= 2)
                 if return_code != 0:
                     raise RequirementException('pip failed to download requirement %s' % requirement_specifier.freeze())
@@ -486,8 +488,9 @@ class Robustus(object):
         self.settings['update_editables'] = args.update_editables
         self.settings['no_remote_cache'] = args.no_remote_cache
         self.settings['ignore_missing_refs'] = args.ignore_missing_refs
+        self.settings['allow_external'] = args.allow_external
         self.settings['allow_all_external'] = args.allow_all_external
-        self.settings['allow_all_unverified'] = args.allow_all_unverified
+        self.settings['allow_unverified'] = args.allow_unverified
 
         tag = args.tag
         if tag is not None:
@@ -881,12 +884,17 @@ class Robustus(object):
                                     help='Number of attempts to install a package.'
                                          'Usefull when working with a bad network when network errors are possible',
                                     default = 2)
+        install_parser.add_argument('--allow-external',
+                                    action='store',
+                                    nargs='+',
+                                    help='allow pip to install selected external packages')
         install_parser.add_argument('--allow-all-external',
                                     action='store_true',
                                     help='allow pip to install external packages')
-        install_parser.add_argument('--allow-all-unverified',
-                                    action='store_true',
-                                    help='allow pip to install unverified packages')
+        install_parser.add_argument('--allow-unverified',
+                                    action='store',
+                                    nargs='+',
+                                    help='allow pip to install selected unverified packages')
         install_parser.set_defaults(func=Robustus.install)
 
         perrepo_parser = subparsers.add_parser('perrepo',

--- a/robustus/robustus.py
+++ b/robustus/robustus.py
@@ -264,11 +264,11 @@ class Robustus(object):
                 logging.info('Wheel not found, downloading package')
                 cmd = [self.pip_executable, 'install', '--download', self.cache, requirement_specifier.freeze()]
                 if len(self.settings['allow_external']) > 0:
-                    cmd.append('--allow-external ' + ' '.join(self.settings['allow_external']))
+                    cmd += ['--allow-external '] + self.settings['allow_external']
                 if self.settings['allow_all_external']:
                     cmd.append('--allow-all-external')
                 if len(self.settings['allow_unverified']) > 0:
-                    cmd.append('--allow-unverified ' + ' '.join(self.settings['allow_unverified']))
+                    cmd += ['--allow-unverified '] + self.settings['allow_unverified']
                 return_code = run_shell(cmd, verbose=self.settings['verbosity'] >= 2)
                 if return_code != 0:
                     raise RequirementException('pip failed to download requirement %s' % requirement_specifier.freeze())

--- a/robustus/robustus.py
+++ b/robustus/robustus.py
@@ -887,6 +887,7 @@ class Robustus(object):
         install_parser.add_argument('--allow-external',
                                     action='store',
                                     nargs='+',
+                                    default=[],
                                     help='allow pip to install selected external packages')
         install_parser.add_argument('--allow-all-external',
                                     action='store_true',
@@ -894,6 +895,7 @@ class Robustus(object):
         install_parser.add_argument('--allow-unverified',
                                     action='store',
                                     nargs='+',
+                                    default=[],
                                     help='allow pip to install selected unverified packages')
         install_parser.set_defaults(func=Robustus.install)
 

--- a/robustus/tests/test_pyaudio.py
+++ b/robustus/tests/test_pyaudio.py
@@ -10,8 +10,8 @@ from robustus.detail import perform_standard_test
 def test_pyaudio_installation(tmpdir):
     tmpdir.chdir()
     exprs = ['import pyaudio']
-    options = ['--allow-external', 'PyAudio', '--allow-unverified', 'PyAudio']
-    perform_standard_test('PyAudio==0.2.8', exprs, [], [], options=options)
+    install_options = ['--allow-external', 'PyAudio', '--allow-unverified', 'PyAudio']
+    perform_standard_test('PyAudio==0.2.8', exprs, [], [], install_options=install_options)
 
 
 if __name__ == '__main__':

--- a/robustus/tests/test_pyaudio.py
+++ b/robustus/tests/test_pyaudio.py
@@ -1,0 +1,17 @@
+# =============================================================================
+# COPYRIGHT 2013 Brain Corporation.
+# License under MIT license (see LICENSE file)
+# =============================================================================
+
+import pytest
+from robustus.detail import perform_standard_test
+
+
+def test_pyaudio_installation(tmpdir):
+    tmpdir.chdir()
+    exprs = ['import pyaudio']
+    perform_standard_test('PyAudio==0.2.7 --allow-external PyAudio --allow-unverified PyAudio', exprs, [], [])
+
+
+if __name__ == '__main__':
+    pytest.main('-s %s -n0' % __file__)

--- a/robustus/tests/test_pyaudio.py
+++ b/robustus/tests/test_pyaudio.py
@@ -10,7 +10,8 @@ from robustus.detail import perform_standard_test
 def test_pyaudio_installation(tmpdir):
     tmpdir.chdir()
     exprs = ['import pyaudio']
-    perform_standard_test('PyAudio==0.2.8 --allow-external PyAudio --allow-unverified PyAudio', exprs, [], [])
+    options = ['--allow-external', 'PyAudio', '--allow-unverified', 'PyAudio']
+    perform_standard_test('PyAudio==0.2.8', exprs, [], [], options=options)
 
 
 if __name__ == '__main__':

--- a/robustus/tests/test_pyaudio.py
+++ b/robustus/tests/test_pyaudio.py
@@ -10,7 +10,7 @@ from robustus.detail import perform_standard_test
 def test_pyaudio_installation(tmpdir):
     tmpdir.chdir()
     exprs = ['import pyaudio']
-    perform_standard_test('PyAudio==0.2.7 --allow-external PyAudio --allow-unverified PyAudio', exprs, [], [])
+    perform_standard_test('PyAudio==0.2.8 --allow-external PyAudio --allow-unverified PyAudio', exprs, [], [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
--allow-external, --allow-all-externa, --allow-unverified options for install (passed to pip). New pip requires these options for some packages. For example we'll almost always will need --allow-unverified PIL, because numpy is not going to be installed without this option.